### PR TITLE
Remove pryr dependency in favor of base object.size()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,5 +9,5 @@ License: MIT
 Encoding: UTF-8
 LazyData: true
 Imports:
-	httr,dplyr,pryr,tibble,tidyr,readr,RCurl,rjson
+	httr,dplyr,tibble,tidyr,readr,RCurl,rjson
 RoxygenNote: 7.1.0

--- a/R/rdomo.R
+++ b/R/rdomo.R
@@ -262,7 +262,7 @@ DomoUtilities <- setRefClass("DomoUtilities",
 			return(x$id)
 		},
 		estimate_rows=function (data, kbytes = 10000) {
-			sz <- as.numeric(pryr::object_size(data))
+			sz <- as.numeric(object.size(data))
 			targetSize <- kbytes * 3 # compression factor
 			if (sz / 1000 > targetSize)
 				return(floor(nrow(data)*(targetSize) / (sz/1000)))


### PR DESCRIPTION
## Problem

`pryr` is no longer available on CRAN for recent R versions (e.g. R 4.6). This causes `devtools::install_github('domoinc/rdomo')` to fail during dependency installation:

> package 'pryr' is not available for this version of R

## Change

`pryr` was used in exactly one place — `DomoUtilities$estimate_rows()` — to approximate the in-memory byte size of a data frame for row chunking:

```r
sz <- as.numeric(pryr::object_size(data))
```

Base R's `utils::object.size()` (always available, no external dependency) serves the same purpose:

```r
sz <- as.numeric(object.size(data))
```

- `R/rdomo.R` — swap `pryr::object_size()` → `object.size()`
- `DESCRIPTION` — drop `pryr` from `Imports`

## Notes

`pryr::object_size()` accounts for shared references more precisely than `utils::object.size()`, but the difference is immaterial here: the result feeds a deliberately fuzzy estimate with a hardcoded compression factor for row chunking. Removing the dependency makes the package installable on current R with no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)